### PR TITLE
Modified ITOPD8 variables in BFVOLUME and VOLUME keyword logic in ini…

### DIFF
--- a/vbase/initre.f
+++ b/vbase/initre.f
@@ -1682,7 +1682,8 @@ C
       SELECT CASE (VARACD)
 C
         CASE ('SN')
-          ITOPD8=1
+C  Updates to fvsvol.f now allow for this option in R8 (Q1 2023)
+          ITOPD8=0
 C
         CASE DEFAULT
           ITOPD8=0
@@ -1933,7 +1934,9 @@ C
       SELECT CASE (VARACD)
 C
         CASE ('SN')
-          ITOPD8=1
+C          ITOPD8=1
+C  Updates to fvsvol.f now allow for this option in R8 (Q1 2023)
+          ITOPD8=0
 C
         CASE DEFAULT
           ITOPD8=0


### PR DESCRIPTION
…tre.f

When combined with updates to fvsvol.f done in the NVELrefactor branch, this will allow users in Region 8 to input their own minimum top diameter specifications